### PR TITLE
Validate GitLab webhook token and reject unauthorized requests

### DIFF
--- a/app/routers/webhooks.py
+++ b/app/routers/webhooks.py
@@ -1,15 +1,22 @@
-from fastapi import APIRouter, Request, Header
+from fastapi import APIRouter, Request, Header, HTTPException
 import structlog
 from ..services.review_service import trigger_review
+from ..config import settings
 
 router = APIRouter()
 
 
 @router.post("/gitlab/webhook")
 async def gitlab_webhook(request: Request, x_gitlab_token: str = Header(None)):
+    if x_gitlab_token != settings.webhook_secret:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
     payload = await request.json()
     # For brevity, only respond to manual trigger in tests
-    if payload.get("object_kind") == "note" and payload.get("object_attributes", {}).get("note") == "/ai-review":
+    if (
+        payload.get("object_kind") == "note"
+        and payload.get("object_attributes", {}).get("note") == "/ai-review"
+    ):
         project_id = payload["project"]["id"]
         mr_iid = payload["merge_request"]["iid"]
         await trigger_review(project_id, mr_iid)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.config import settings
+
+
+def test_webhook_rejects_invalid_token():
+    original = settings.webhook_secret
+    settings.webhook_secret = "secret"
+    client = TestClient(app)
+    try:
+        response = client.post("/gitlab/webhook", json={})
+        assert response.status_code == 401
+        response = client.post(
+            "/gitlab/webhook", json={}, headers={"X-Gitlab-Token": "wrong"}
+        )
+        assert response.status_code == 401
+    finally:
+        settings.webhook_secret = original


### PR DESCRIPTION
## Summary
- enforce webhook token authentication for GitLab webhook requests
- add tests covering unauthorized webhook requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988cb1a65c8326983e8407e5cb12d2