### PR TITLE
Trigger review on merge request events

### DIFF
--- a/app/routers/webhooks.py
+++ b/app/routers/webhooks.py
@@ -12,12 +12,20 @@ async def gitlab_webhook(request: Request, x_gitlab_token: str = Header(None)):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     payload = await request.json()
-    # For brevity, only respond to manual trigger in tests
-    if (
+
+    if payload.get("object_kind") == "merge_request":
+        action = payload.get("object_attributes", {}).get("action")
+        if action in {"open", "update"}:
+            project_id = payload["project"]["id"]
+            mr_iid = payload["object_attributes"]["iid"]
+            await trigger_review(project_id, mr_iid)
+
+    elif (
         payload.get("object_kind") == "note"
         and payload.get("object_attributes", {}).get("note") == "/ai-review"
     ):
         project_id = payload["project"]["id"]
         mr_iid = payload["merge_request"]["iid"]
         await trigger_review(project_id, mr_iid)
+
     return {"status": "ok"}

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,6 +1,8 @@
 from fastapi.testclient import TestClient
 from app.main import app
 from app.config import settings
+from app.routers import webhooks
+import pytest
 
 
 def test_webhook_rejects_invalid_token():
@@ -14,5 +16,33 @@ def test_webhook_rejects_invalid_token():
             "/gitlab/webhook", json={}, headers={"X-Gitlab-Token": "wrong"}
         )
         assert response.status_code == 401
+    finally:
+        settings.webhook_secret = original
+
+
+@pytest.mark.parametrize("action", ["open", "update"])
+def test_merge_request_actions_trigger_review(monkeypatch, action):
+    original = settings.webhook_secret
+    settings.webhook_secret = "secret"
+    called = []
+
+    async def fake_trigger_review(project_id, mr_iid):
+        called.append((project_id, mr_iid))
+
+    monkeypatch.setattr(webhooks, "trigger_review", fake_trigger_review)
+    client = TestClient(app)
+    try:
+        payload = {
+            "object_kind": "merge_request",
+            "project": {"id": 1},
+            "object_attributes": {"iid": 2, "action": action},
+        }
+        response = client.post(
+            "/gitlab/webhook",
+            json=payload,
+            headers={"X-Gitlab-Token": "secret"},
+        )
+        assert response.status_code == 200
+        assert called == [(1, 2)]
     finally:
         settings.webhook_secret = original


### PR DESCRIPTION
## Summary
- run reviews automatically when merge requests are opened or updated
- test GitLab webhook auto-trigger behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68988d9edecc8326bbafab69f76dbcbf