### PR TITLE
Run reviews in background tasks

### DIFF
--- a/app/routers/reviews.py
+++ b/app/routers/reviews.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, BackgroundTasks
 from pydantic import BaseModel
 from ..services.review_service import trigger_review, get_current_findings
 
@@ -11,8 +11,10 @@ class RunReviewRequest(BaseModel):
 
 
 @router.post("/reviews/run")
-async def run_review(body: RunReviewRequest):
-    await trigger_review(body.project_id, body.mr_iid)
+async def run_review(body: RunReviewRequest, background_tasks: BackgroundTasks):
+    """Schedule a review run in the background."""
+
+    background_tasks.add_task(trigger_review, body.project_id, body.mr_iid)
     return {"status": "queued"}
 
 


### PR DESCRIPTION
## Summary
- Queue MR reviews using FastAPI BackgroundTasks for GitLab webhooks
- Allow manual review triggers to schedule work in the background

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988ea8b2f48326a063d105171954db